### PR TITLE
Add acceleration processing

### DIFF
--- a/modules/data_processing.py
+++ b/modules/data_processing.py
@@ -1,6 +1,51 @@
 import pandas as pd
+import numpy as np
 
 def preprocess_data(df):
     # データの前処理をここに記述
     df = df.dropna()  # 例: 欠損値の削除
     return df
+
+
+def rotate_xy(df: pd.DataFrame, x_col: str, y_col: str, angle_deg: float) -> pd.DataFrame:
+    """Rotate X and Y columns by the given angle.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Source dataframe containing X and Y columns.
+    x_col, y_col : str
+        Column names corresponding to X and Y axes.
+    angle_deg : float
+        Rotation angle in degrees. Positive is counter-clockwise.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with two columns ``x_rot`` and ``y_rot`` containing the rotated values.
+    """
+    angle_rad = np.deg2rad(angle_deg)
+    x = df[x_col].astype(float)
+    y = df[y_col].astype(float)
+    x_rot = x * np.cos(angle_rad) - y * np.sin(angle_rad)
+    y_rot = x * np.sin(angle_rad) + y * np.cos(angle_rad)
+    return pd.DataFrame({"x_rot": x_rot, "y_rot": y_rot})
+
+
+def calc_accel_metrics(series: pd.Series) -> dict:
+    """Calculate acceleration metrics for a numeric series.
+
+    Returns a dictionary with RMS, max, min and peak-to-peak values.
+    """
+    values = series.astype(float)
+    rms = np.sqrt(np.mean(values ** 2))
+    max_val = values.max()
+    min_val = values.min()
+    p2p = max_val - min_val
+    return {
+        "rms": rms,
+        "max": max_val,
+        "min": min_val,
+        "p2p": p2p,
+    }
+

--- a/test/test_acceleration_processing.py
+++ b/test/test_acceleration_processing.py
@@ -1,0 +1,25 @@
+import unittest
+import os
+import sys
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from modules.data_processing import rotate_xy, calc_accel_metrics
+
+class TestAccelerationProcessing(unittest.TestCase):
+    def test_rotate_xy(self):
+        df = pd.DataFrame({'x':[1,0], 'y':[0,1]})
+        rotated = rotate_xy(df, 'x', 'y', 90)
+        self.assertAlmostEqual(rotated['x_rot'].iloc[0], 0, places=5)
+        self.assertAlmostEqual(rotated['y_rot'].iloc[0], 1, places=5)
+    def test_calc_metrics(self):
+        s = pd.Series([1, -1, 1, -1])
+        metrics = calc_accel_metrics(s)
+        self.assertAlmostEqual(metrics['rms'], 1, places=5)
+        self.assertEqual(metrics['max'], 1)
+        self.assertEqual(metrics['min'], -1)
+        self.assertEqual(metrics['p2p'], 2)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_sample_test.py
+++ b/test/test_sample_test.py
@@ -1,5 +1,10 @@
 # test/test_sample_data.py
 import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from modules.sample_data import load_simple_sample_data, load_timeseries_sample_data
 
 class TestSampleData(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add utilities for rotating acceleration data and computing metrics
- expand data visualization app for acceleration use case
- add tests for new utilities
- fix existing tests to work without PYTHONPATH configuration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6878a169d21483209ce4ff76e9c0ce04