### PR TITLE
Add FFT option for acceleration plots

### DIFF
--- a/modules/plot.py
+++ b/modules/plot.py
@@ -98,3 +98,21 @@ def create_plot(chart_type, df, settings):
         return fig, settings['graph_title']
 
     return None, None
+
+
+def create_fft_plot(freqs, amp_df):
+    """Create a line plot of FFT results."""
+    colors = px.colors.qualitative.Light24
+    fig = go.Figure()
+    for i, col in enumerate(amp_df.columns):
+        fig.add_trace(
+            go.Scatter(x=freqs, y=amp_df[col], mode="lines", name=col, marker=dict(color=colors[i]))
+        )
+    fig.update_layout(
+        title={"text": "FFT結果", "x": 0.5, "xanchor": "center"},
+        xaxis_title="周波数(Hz)",
+        yaxis_title="加速度",
+        xaxis=dict(tickfont=dict(size=12)),
+        yaxis=dict(tickfont=dict(size=12)),
+    )
+    return fig

--- a/test/test_fft.py
+++ b/test/test_fft.py
@@ -1,0 +1,24 @@
+import unittest
+import os
+import sys
+import numpy as np
+import pandas as pd
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from modules.data_processing import compute_fft
+
+class TestFFT(unittest.TestCase):
+    def test_compute_fft_peak(self):
+        t = np.linspace(0, 1, 256, endpoint=False)
+        df = pd.DataFrame({
+            'X': np.sin(2*np.pi*10*t),
+            'Y': np.sin(2*np.pi*20*t),
+            'Z': np.sin(2*np.pi*30*t),
+            'Time': t
+        })
+        freqs, amp_df = compute_fft(df, 0.0, 256)
+        self.assertAlmostEqual(freqs[np.argmax(amp_df['X'])], 10, places=6)
+        self.assertAlmostEqual(freqs[np.argmax(amp_df['Y'])], 20, places=6)
+        self.assertAlmostEqual(freqs[np.argmax(amp_df['Z'])], 30, places=6)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement FFT calculation and plotting utilities
- store rotated acceleration and add FFT controls to UI
- expose FFT settings when purpose is acceleration
- unit test for FFT

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_6878ad3e02fc8320bc501f14c8cf7d53