### PR TITLE
Add FFT heatmap and time selection

### DIFF
--- a/modules/plot.py
+++ b/modules/plot.py
@@ -116,3 +116,18 @@ def create_fft_plot(freqs, amp_df):
         yaxis=dict(tickfont=dict(size=12)),
     )
     return fig
+
+
+def create_fft_heatmap(freqs, times, amp_matrix, axis_label=""):
+    """Create a heatmap showing FFT amplitude over time."""
+    heatmap = go.Heatmap(z=amp_matrix, x=times, y=freqs, colorscale="Viridis")
+    title = "FFTヒートマップ" if axis_label == "" else f"{axis_label} FFTヒートマップ"
+    layout = go.Layout(
+        title={"text": title, "x": 0.5, "xanchor": "center"},
+        xaxis_title="時間(sec)",
+        yaxis_title="周波数(Hz)",
+        xaxis=dict(tickfont=dict(size=12)),
+        yaxis=dict(tickfont=dict(size=12)),
+    )
+    fig = go.Figure(data=[heatmap], layout=layout)
+    return fig

--- a/test/test_fft.py
+++ b/test/test_fft.py
@@ -4,7 +4,7 @@ import sys
 import numpy as np
 import pandas as pd
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from modules.data_processing import compute_fft
+from modules.data_processing import compute_fft, compute_fft_segments
 
 class TestFFT(unittest.TestCase):
     def test_compute_fft_peak(self):
@@ -15,10 +15,17 @@ class TestFFT(unittest.TestCase):
             'Z': np.sin(2*np.pi*30*t),
             'Time': t
         })
-        freqs, amp_df = compute_fft(df, 0.0, 256)
+        freqs, amp_df, _ = compute_fft(df, 0.0, 256)
         self.assertAlmostEqual(freqs[np.argmax(amp_df['X'])], 10, places=6)
         self.assertAlmostEqual(freqs[np.argmax(amp_df['Y'])], 20, places=6)
         self.assertAlmostEqual(freqs[np.argmax(amp_df['Z'])], 30, places=6)
+
+    def test_compute_fft_segments_shape(self):
+        t = np.linspace(0, 1, 128, endpoint=False)
+        df = pd.DataFrame({'X': np.sin(2*np.pi*10*t), 'Time': t})
+        freqs, times, spec_dict, _ = compute_fft_segments(df, 32)
+        self.assertEqual(spec_dict['X'].shape, (17, 4))
+        self.assertAlmostEqual(times[-1], 0.75, places=6)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- support configurable time column and units when processing acceleration data
- allow axes to be optional when converting acceleration data
- plot graphs using the converted data
- compute repeated FFT segments and show heatmaps
- test FFT segment helper

## Testing
- `python -m py_compile modules/*.py test/*.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6879d1821db0832082db5a6a1909de82